### PR TITLE
Add screenshot capture tool

### DIFF
--- a/UnityMcpBridge/Editor/Tools/CaptureView.cs
+++ b/UnityMcpBridge/Editor/Tools/CaptureView.cs
@@ -1,0 +1,86 @@
+using System;
+using Newtonsoft.Json.Linq;
+using UnityEditor;
+using UnityEngine;
+using UnityMcpBridge.Editor.Helpers;
+
+namespace UnityMcpBridge.Editor.Tools
+{
+    /// <summary>
+    /// Captures screenshots of the Game or Scene view and returns them as base64 strings.
+    /// </summary>
+    public static class CaptureView
+    {
+        /// <summary>
+        /// Main handler for view capture actions.
+        /// </summary>
+        public static object HandleCommand(JObject @params)
+        {
+            string action = @params["action"]?.ToString().ToLower() ?? "capture";
+            string target = @params["target"]?.ToString()?.ToLower() ?? "game";
+
+            switch (action)
+            {
+                case "capture":
+                    return Capture(target);
+                default:
+                    return Response.Error($"Unknown action: '{action}'. Valid action is 'capture'.");
+            }
+        }
+
+        private static object Capture(string target)
+        {
+            try
+            {
+                Texture2D screenshot = null;
+
+                if (target == "scene")
+                {
+                    SceneView sceneView = SceneView.lastActiveSceneView;
+                    if (sceneView == null)
+                    {
+                        return Response.Error("No active Scene view found.");
+                    }
+
+                    Camera cam = sceneView.camera;
+                    int width = Mathf.RoundToInt(sceneView.position.width);
+                    int height = Mathf.RoundToInt(sceneView.position.height);
+                    RenderTexture rt = new RenderTexture(width, height, 24);
+                    cam.targetTexture = rt;
+                    cam.Render();
+                    RenderTexture.active = rt;
+                    screenshot = new Texture2D(width, height, TextureFormat.RGB24, false);
+                    screenshot.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                    screenshot.Apply();
+                    cam.targetTexture = null;
+                    RenderTexture.active = null;
+                    UnityEngine.Object.DestroyImmediate(rt);
+                }
+                else // default to game view
+                {
+                    screenshot = ScreenCapture.CaptureScreenshotAsTexture();
+                }
+
+                if (screenshot == null)
+                {
+                    return Response.Error("Failed to capture screenshot.");
+                }
+
+                byte[] pngData = screenshot.EncodeToPNG();
+                string base64 = Convert.ToBase64String(pngData);
+                int widthOut = screenshot.width;
+                int heightOut = screenshot.height;
+                UnityEngine.Object.DestroyImmediate(screenshot);
+
+                return Response.Success(
+                    "Captured screenshot.",
+                    new { base64 = base64, width = widthOut, height = heightOut }
+                );
+            }
+            catch (Exception e)
+            {
+                return Response.Error($"Capture failed: {e.Message}");
+            }
+        }
+    }
+}

--- a/UnityMcpBridge/Editor/Tools/CommandRegistry.cs
+++ b/UnityMcpBridge/Editor/Tools/CommandRegistry.cs
@@ -20,6 +20,7 @@ namespace UnityMcpBridge.Editor.Tools
             { "HandleManageAsset", ManageAsset.HandleCommand },
             { "HandleReadConsole", ReadConsole.HandleCommand },
             { "HandleExecuteMenuItem", ExecuteMenuItem.HandleCommand },
+            { "HandleCaptureView", CaptureView.HandleCommand },
         };
 
         /// <summary>

--- a/UnityMcpServer/src/tools/__init__.py
+++ b/UnityMcpServer/src/tools/__init__.py
@@ -5,6 +5,7 @@ from .manage_gameobject import register_manage_gameobject_tools
 from .manage_asset import register_manage_asset_tools
 from .read_console import register_read_console_tools
 from .execute_menu_item import register_execute_menu_item_tools
+from .capture_view import register_capture_view_tools
 
 def register_all_tools(mcp):
     """Register all refactored tools with the MCP server."""
@@ -16,4 +17,5 @@ def register_all_tools(mcp):
     register_manage_asset_tools(mcp)
     register_read_console_tools(mcp)
     register_execute_menu_item_tools(mcp)
+    register_capture_view_tools(mcp)
     print("Unity MCP Server tool registration complete.")

--- a/UnityMcpServer/src/tools/capture_view.py
+++ b/UnityMcpServer/src/tools/capture_view.py
@@ -1,0 +1,36 @@
+from mcp.server.fastmcp import FastMCP, Context
+from typing import Dict, Any
+from unity_connection import get_unity_connection
+
+
+def register_capture_view_tools(mcp: FastMCP):
+    """Register the capture_view tool with the MCP server."""
+
+    @mcp.tool()
+    def capture_view(ctx: Context, target: str = "game") -> Dict[str, Any]:
+        """Capture a screenshot of the specified Unity view.
+
+        Args:
+            ctx: The MCP context.
+            target: View to capture ('game' or 'scene').
+
+        Returns:
+            Dictionary with success status, message and data containing the
+            base64 encoded PNG image.
+        """
+        params = {"action": "capture", "target": target}
+        try:
+            response = get_unity_connection().send_command("capture_view", params)
+            if response.get("success"):
+                return {
+                    "success": True,
+                    "message": response.get("message", "Captured view."),
+                    "data": response.get("data"),
+                }
+            else:
+                return {
+                    "success": False,
+                    "message": response.get("error", "Unknown error capturing view."),
+                }
+        except Exception as e:
+            return {"success": False, "message": f"Python error capturing view: {str(e)}"}


### PR DESCRIPTION
## Summary
- capture Unity Game or Scene view images via new `CaptureView` tool
- register `capture_view` with the MCP Python server

## Testing
- `python3 -m py_compile UnityMcpServer/src/*.py UnityMcpServer/src/tools/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6854307ccf448332ba2cb66b9db8be74